### PR TITLE
QA commands round 1

### DIFF
--- a/cogs/qanda.py
+++ b/cogs/qanda.py
@@ -253,7 +253,7 @@ class Qanda(commands.Cog):
         try:
             message = await ctx.fetch_message(q[3])
         except NotFound:
-            nf_str = f"Question {num} not found in channel. It may have been deleted."
+            nf_str = f"Q{num} is a ghost!"
             await ctx.author.send(nf_str)
             # delete user msg
             await ctx.message.delete()

--- a/cogs/qanda.py
+++ b/cogs/qanda.py
@@ -125,7 +125,7 @@ class Qanda(commands.Cog):
         q = db.query('SELECT number, question, author_id, msg_id FROM questions WHERE guild_id = %s AND number = %s',
                      (ctx.guild.id, num))
         if len(q) == 0:
-            await ctx.author.send('Invalid question number: ' + str(num))
+            await ctx.author.send('No such question with the number: ' + str(num))
             # delete user msg
             await ctx.message.delete()
             return
@@ -135,7 +135,8 @@ class Qanda(commands.Cog):
         try:
             message = await ctx.fetch_message(q[3])
         except NotFound:
-            await ctx.author.send('Invalid question number: ' + str(num))
+            nf_str = f"Question {num} not found. It may have been deleted."
+            await ctx.author.send(nf_str)
             # delete user msg
             await ctx.message.delete()
             return
@@ -165,7 +166,9 @@ class Qanda(commands.Cog):
         try:
             await message.edit(content=new_answer)
         except NotFound:
-            await ctx.author.send('Invalid question number: ' + str(num))
+            nf_str = f"Question {num} not found. It may have been deleted."
+            await ctx.author.send(nf_str)
+            #await ctx.author.send('Invalid question number: ' + str(num))
 
         # delete user msg
         await ctx.message.delete()
@@ -224,7 +227,7 @@ class Qanda(commands.Cog):
         q = db.query('SELECT number, question, author_id, msg_id FROM questions WHERE guild_id = %s AND number = %s',
                      (ctx.guild.id, num))
         if len(q) == 0:
-            await ctx.author.send('Invalid question number: ' + str(num))
+            await ctx.author.send('No such question with the number: ' + str(num))
             # delete user msg
             await ctx.message.delete()
             return
@@ -312,7 +315,7 @@ class Qanda(commands.Cog):
         q = db.query('SELECT number, question, author_id, msg_id FROM questions WHERE guild_id = %s AND number = %s',
                      (ctx.guild.id, num))
         if len(q) == 0:
-            await ctx.author.send('Invalid question number: ' + str(num))
+            await ctx.author.send('No such question with the number: ' + str(num))
             # delete user msg
             await ctx.message.delete()
             return
@@ -350,12 +353,8 @@ class Qanda(commands.Cog):
 
         # send the question and answers to user
         await ctx.author.send(qstr)
-
-        # delete user msg
-        #try:
         await ctx.message.delete()
-        #except NotFound:
-        #    pass
+
 
     # -----------------------------------------------------------------------------------------------------------------
     #    Function: getAllAnsFor_error(self, ctx, error)
@@ -398,7 +397,7 @@ class Qanda(commands.Cog):
             return
 
         # get questions
-        q = db.query('SELECT number, question, author_id, msg_id FROM questions WHERE guild_id = %s',
+        q = db.query('SELECT number, question, author_id, msg_id FROM questions WHERE guild_id = %s ORDER BY number ASC',
                      (ctx.guild.id,))
         if len(q) == 0:
             await ctx.author.send('No questions found in database.')
@@ -568,7 +567,7 @@ class Qanda(commands.Cog):
             return
 
        # check if question number exists
-        q = db.query('SELECT number, msg_id FROM questions WHERE guild_id = %s AND number = %s',
+        q = db.query('SELECT number, msg_id, is_ghost FROM questions WHERE guild_id = %s AND number = %s',
                      (ctx.guild.id, num))
         if len(q) == 0:
             await ctx.author.send('Question number not in database: ' + str(num))
@@ -577,6 +576,11 @@ class Qanda(commands.Cog):
             return
 
         q = q[0]
+
+        # if is_ghost is false, set to true
+        if not q[2]:
+            db.query('UPDATE questions SET is_ghost = NOT is_ghost WHERE guild_id = %s AND number = %s',
+            (ctx.guild.id, num))
 
         # check if message exists on channel
         try:

--- a/cogs/qanda.py
+++ b/cogs/qanda.py
@@ -3,6 +3,7 @@
 from discord import NotFound
 from discord.ext import commands
 import db
+import re
 
 
 class Qanda(commands.Cog):
@@ -98,6 +99,17 @@ class Qanda(commands.Cog):
             await ctx.author.send('Please send answers to the #q-and-a channel.')
             await ctx.message.delete()
             return
+        
+        # to stop SQL from freezing. Only allows valid numbers.
+        if not re.match('^([1-9]\d*|0)$', num):
+            await ctx.author.send('Please include a valid question number. EX: $answer 1 /"Oct 12/" anonymous')
+            await ctx.message.delete()
+            return
+        
+        #if not isinstance(ans, str):
+            #await ctx.author.send('Please include a valid answer. EX: $answer 1 /"Oct 12/" anonymous')
+           # await ctx.message.delete()
+           # return
 
         # get author
         if anonymous == '':
@@ -134,7 +146,7 @@ class Qanda(commands.Cog):
         else:
             role = 'Student'
         db.query(
-            'INSERT INTO answers (guild_id, q_number, answer, author_id, author_role) VALUES (%s, %s, %s, %s, %s)',
+            'INSERT INTO answers (guild_id, q_number, answers, author_id, author_role) VALUES (%s, %s, %s, %s, %s)',
             (ctx.guild.id, num, ans, author, role)
         )
 
@@ -176,6 +188,199 @@ class Qanda(commands.Cog):
         else:
             await ctx.author.send(error)
         await ctx.message.delete()
+
+
+    ##### NEW COMMANDS HERE
+    #TODO
+    #getOneAnswer (q_num) (ans_num)
+    #getLatestAnswer (q_num)
+    #deleteAllAnswersFor (q_num) #instructor
+    #deleteOneAnswerFor (q_num) (ans_num) #instructor
+    #deleteEmptyAnswersFor (q_num) #instructor
+    #deleteAllEmptyAnswers #instructor
+
+    #TODO
+    #deleteQuestion (q_num) #ALSO DELETES ALL ANSWERS FOR THIS QUESTION. instructor only
+    #deleteAllQuestions    #instructor only
+    #deleteAllQuestionsBy ... 
+    #deleteAllEmptyQuestions
+
+    #archiveQA (DM all questions and their answers)
+
+
+    #deleteAllAnswersFor (q_num) #instructor
+    # -----------------------------------------------------------------------------------------------------------------
+    #    Function: deleteAllAnswersFor
+    #    Description: 
+    #    Inputs:
+    #       - ctx: context of the command
+    #       - num: question number
+    #    Outputs:
+    #       - 
+    # -----------------------------------------------------------------------------------------------------------------
+    @commands.has_role('Instructor')
+    @commands.command(name='DALLAF', help='(PLACEHOLDER NAME) Delete all answers for a question\n'
+                                       'EX: $DALLAF 1')
+    async def deleteAllAnsFor(self, ctx, num):
+
+        # make sure to check that this is actually being asked in the Q&A channel
+        if not ctx.channel.name == 'q-and-a':
+            await ctx.author.send('Please use this command inside the #q-and-a channel.')
+            await ctx.message.delete()
+            return
+        
+        # to stop SQL from freezing. Only allows valid numbers.
+        if not re.match('^([1-9]\d*|0)$', num):
+            await ctx.author.send('Please include a valid question number. EX: $answer 1 /"Oct 12/" anonymous')
+            await ctx.message.delete()
+            return
+        
+        # check if question number exists
+        q = db.query('SELECT number, question, author_id, msg_id FROM questions WHERE guild_id = %s AND number = %s',
+                     (ctx.guild.id, num))
+        if len(q) == 0:
+            await ctx.author.send('Invalid question number: ' + str(num))
+            # delete user msg
+            await ctx.message.delete()
+            return
+        q = q[0]
+
+        # retrieve question msg
+        q_author_str = 'anonymous' if q[2] is None else (await self.bot.fetch_user(q[2])).name
+        qstr = f"Q{q[0]}: {q[1]} by {q_author_str}\n"
+
+        rows_deleted = db.query(
+            'SELECT * FROM answers WHERE guild_id = %s AND q_number = %s',
+            (ctx.guild.id, num)
+        )
+        # Delete all answers for question
+        answers = db.query('DELETE FROM answers WHERE guild_id = %s AND q_number = %s',
+                           (ctx.guild.id, num))
+        
+        if len(rows_deleted) == 0:
+            await ctx.send(
+                f"No answers exist for Q{num}")
+        else:
+            await ctx.send(
+                f"deleted {len(rows_deleted)} answers for Q{num}")
+        
+        # check if message exists on the channel. If it does, restore the question!
+        try:
+            message = await ctx.fetch_message(q[3])
+        except NotFound:
+            nf_str = f"Question {num} not found in channel. It may have been deleted."
+            await ctx.author.send(nf_str)
+            # delete user msg
+            await ctx.message.delete()
+            return
+
+        await message.edit(content=qstr)
+        # delete user msg
+        await ctx.message.delete()
+
+    # -----------------------------------------------------------------------------------------------------------------
+    #    Function: deleteAllAnswersFor_error(self, ctx, error)
+    #    Description: prints error message for deleteAllAnswersFor command
+    #    Inputs:
+    #       - ctx: context of the command
+    #       - error: error message
+    #    Outputs:
+    #       - Error details
+    # -----------------------------------------------------------------------------------------------------------------
+    @deleteAllAnsFor.error
+    async def deleteAllAnsFor_error(self, ctx, error):
+        if isinstance(error, commands.MissingRequiredArgument):
+            await ctx.author.send(
+                'To use the deleteAllAnswersFor command, do: $DALLAF QUESTION_NUMBER\n '
+                '(Example: $DALLAF 1)')
+        else:
+            await ctx.author.send(error)
+        await ctx.message.delete()
+
+    #getAnswersFor (q_num)
+    # -----------------------------------------------------------------------------------------------------------------
+    #    Function: getAnswersFor
+    #    Description: gets all answers for a question
+    #    Inputs:
+    #       - ctx: context of the command
+    #       - num: question number
+    #    Outputs:
+    #       - All questions and their answers, if any
+    # -----------------------------------------------------------------------------------------------------------------
+    @commands.command(name='getAnswersFor', help='Get all answers for a question\n'
+                                       'EX: $getAnswersFor 1')
+    async def getAllAnsFor(self, ctx, num):
+
+        # make sure to check that this is actually being asked in the Q&A channel
+        if not ctx.channel.name == 'q-and-a':
+            await ctx.author.send('Please use this command inside the #q-and-a channel.')
+            await ctx.message.delete()
+            return
+
+        # to stop SQL from screaming. Only allows valid numbers.
+        if not re.match('^([1-9]\d*|0)$', num):
+            await ctx.author.send('Please include a valid question number. EX: $answer 1 /"Oct 12/" anonymous')
+            await ctx.message.delete()
+            return
+        # check if question number exists
+        q = db.query('SELECT number, question, author_id, msg_id FROM questions WHERE guild_id = %s AND number = %s',
+                     (ctx.guild.id, num))
+        if len(q) == 0:
+            await ctx.author.send('Invalid question number: ' + str(num))
+            # delete user msg
+            await ctx.message.delete()
+            return
+        q = q[0]
+
+        # check if message exists
+        try:
+            await ctx.fetch_message(q[3])
+        except NotFound:
+            nf_str = f"Question {num} not found. It may have been deleted."
+            await ctx.author.send(nf_str)
+            # delete user msg
+            await ctx.message.delete()
+            return
+
+        # retrieve question msg
+        q_author_str = 'anonymous' if q[2] is None else (await self.bot.fetch_user(q[2])).name
+        qstr = f"Q{q[0]}: {q[1]} by {q_author_str}\n"
+
+
+        # get all answers for question and add to msg
+        answers = db.query('SELECT answer, author_id, author_role FROM answers WHERE guild_id = %s AND q_number = %s',
+                           (ctx.guild.id, num))
+        for answer, author, role in answers:
+            a_author = 'anonymous' if author is None else (await self.bot.fetch_user(author)).name
+            qstr += f"{a_author} ({role}) Ans: {answer}\n"
+        
+        #msgstr = f"Fetched all answers for question {num}"
+
+        await ctx.author.send(qstr)
+
+        # delete user msg
+        await ctx.message.delete()
+
+    # -----------------------------------------------------------------------------------------------------------------
+    #    Function: getAllAnsFor_error(self, ctx, error)
+    #    Description: prints error message for getAnswersFor command
+    #    Inputs:
+    #       - ctx: context of the command
+    #       - error: error message
+    #    Outputs:
+    #       - Error details
+    # -----------------------------------------------------------------------------------------------------------------
+    @getAllAnsFor.error
+    async def getAllAnsFor_error(self, ctx, error):
+        if isinstance(error, commands.MissingRequiredArgument):
+            await ctx.author.send(
+                'To use the getAnswersFor command, do: $getAnswersFor QUESTION_NUMBER\n '
+                '(Example: $getAnswersFor 1)')
+        else:
+            await ctx.author.send(error)
+        await ctx.message.delete()
+
+
 
 
 def setup(bot):

--- a/init.sql
+++ b/init.sql
@@ -42,5 +42,6 @@ CREATE TABLE questions (
 	number          BIGINT NOT NULL,
     question        VARCHAR NOT NULL,
 	author_id       BIGINT,
-	msg_id          BIGINT NOT NULL
+	msg_id          BIGINT NOT NULL,
+    is_ghost        BOOLEAN DEFAULT false
 );

--- a/init.sql
+++ b/init.sql
@@ -42,7 +42,7 @@ CREATE TABLE questions (
     number          BIGINT NOT NULL,
     question        VARCHAR NOT NULL,
     author_id       BIGINT,
-    msg_id          BIGINT NOT NULL
+    msg_id          BIGINT NOT NULL,
     is_ghost        BOOLEAN DEFAULT false
 );
 


### PR DESCRIPTION
### Summary

<!-- Summarize this PR here! -->

Added 5 new commands, 41 unit tests, and set up for ghost handling.
qanda.py coverage increased from **35%** to **92%**

New commands:

$getAnswersFor (num) -- get all answers for a question 
$DALLAF (num) -- deletes all answers for a question
$archiveQA -- sends all questions and answers to the user via DM
$deleteAllQA: deletes all questions and answers from the database and channel
$deleteQuestion (num): deletes a single question from the channel and leaves a database ghost.

### Changed Files

<!-- None OR list all changed files -->

qanda.py

New commands:
```
$getAnswersFor (num) -- get all answers for a question 
$DALLAF (num) -- deletes all answers for a question
$archiveQA -- sends all questions and answers to the user via DM
$deleteAllQA: deletes all questions and answers from the database and channel
$deleteQuestion (num): deletes a single question from the channel and leaves a database ghost.
```
Added regex to all functions that require a num arg to only allow valid input

Updated a few message strings in qanda.py

Added is_ghost column to init.sql (AND to the database itself)

Updated deleteQuestion command to modify is_ghost value

test_bot.py:
Added 41 unit tests (in order):
```
* (ask)            Test: placeholder test for empty input
* (ask)            Test: asking a question in the wrong channel
* (ask)            Test: unknown anonymous input
* (ask)            Test: incorrect use of ask command: missing args
* (answer)         Test: answering a question in the wrong channel
* (answer)         Test: unknown anonymous input
* (answer)         Test: answering a nonexistent question
* (answer)         Test: placeholder test for empty input
* (answer)         Test: incorrect use of answer command: no args
* (answer)         Test: answering with bad input
* (getAnswersFor)  Test: getAnswersFor in wrong channel
* (getAnswersFor)  Test: getting answers for nonexistent question
* (getAnswersFor)  Test: getAnswersFor with bad input: no arg
* (getAnswersFor)  Test: getting answers with bad input
* (getAnswersFor)  Test: getting answers: no answers
* (archiveQA)      Test: questions exist but there are no answers
* (answer)         Test: answering a question
* (answer)         Test: answering a question anonymously
* (getAnswersFor)  Test: successfully getting answers for a question
* (archiveQA)      Test: questions with answers
* (DALLAF)         Test: deleting answers does not work outside of QA
* (DALLAF)         Test: bad input (no args)
* (DALLAF)         Test: bad input
* (DALLAF)         Test: deleting all answers for a non-existent question
* (DALLAF)         Test: deleting all answers for a question with none
* (DALLAF)         Test: successfully deleting all answers for a question
* (archiveQA)      Test: "good measure" test to check results of deletion
* (deleteQuestion) Test: deleting questions does not work outside of QA
* (deleteQuestion) Test: deleting questions with bad input: no args
* (deleteQuestion) Test: deleting question with bad input
* (deleteQuestion) Test: deleting a non-existent question
* (deleteQuestion) Test: deleting a question
* (deleteQuestion) Test: deleting a ghost question
* (getAnswersFor)  Test: getting answers for a ghost
* (DALLAF)         Test: deleting all answers for a ghost
* (archiveQA)      Test: ensure haunting
* (deleteAllQA)    Test: deleting all QAs does not work outside of QA
* (deleteAllQA)    Test: deleting all QAs
* (deleteAllQA)    Test: deleting all QAs: empty database
* (archiveQA)      Test: empty database
* (archiveQA)      Test: does not work outside of QA
```

### Checklists

<!-- If your changes don't affect working code, delete all checkboxes and write N/A -->

- [x] Did you test your changes locally?  
- [x] Did your changes pass all existing tests?  
- [x] Do test cases exist for your changes? If not, please make or reopen an issue.

----

#### Closing Issues

#### Bugs, Notes

Ghosts will be handled in Q&A **round 2**.

#### Contributors

@snapcat 