### PR TITLE
Use of anon when answering/asking, bugfix

### DIFF
--- a/cogs/qanda.py
+++ b/cogs/qanda.py
@@ -21,7 +21,7 @@ class Qanda(commands.Cog):
     #    Outputs:
     #       - User question in new post
     # -----------------------------------------------------------------------------------------------------------------
-    @commands.command(name='ask', help='Ask question. Please put question text in quotes. Add *anonymous* if desired.'
+    @commands.command(name='ask', help='Ask question. Please put question text in quotes. Add *anonymous* or *anon* if desired.'
                                        'EX: $ask /"When is the exam?/" anonymous')
     async def askQuestion(self, ctx, qs: str, anonymous=''):
 
@@ -31,13 +31,25 @@ class Qanda(commands.Cog):
             await ctx.message.delete()
             return
 
+        if not qs or qs.isspace():
+            await ctx.author.send("Please enter a valid question.")
+            await ctx.message.delete()
+            return
+
+        if len(qs) <= 2:
+            await ctx.author.send('Question too short.')
+            await ctx.message.delete()
+            return
+
         # get author
         if anonymous == '':
             author = ctx.message.author.id
         elif anonymous == 'anonymous':
             author = None
+        elif anonymous == 'anon':
+            author = None
         else:
-            await ctx.author.send('Unknown input for *anonymous* option. Please type **anonymous** or leave blank.')
+            await ctx.author.send('Unknown input for *anonymous* option. Please type **anonymous**, **anon**, or leave blank.')
             await ctx.message.delete()
             return
 
@@ -90,9 +102,9 @@ class Qanda(commands.Cog):
     #      - User answer added to question post
     # -----------------------------------------------------------------------------------------------------------------
     @commands.command(name='answer',
-                      help='Answer question. Please put answer text in quotes. Add *anonymous* if desired.'
+                      help='Answer question. Please put answer text in quotes. Add *anonymous* or *anon* if desired.'
                            'EX: $answer 1 /"Oct 12/" anonymous')
-    async def answer(self, ctx, num, ans, anonymous=''):
+    async def answer(self, ctx, num, ans: str, anonymous=''):
         ''' answer the specific question '''
         # make sure to check that this is actually being asked in the Q&A channel
         if not ctx.channel.name == 'q-and-a':
@@ -100,24 +112,31 @@ class Qanda(commands.Cog):
             await ctx.message.delete()
             return
 
-        # to stop SQL from freezing. Only allows valid numbers.
-        if not re.match(r'^([1-9]\d*|0)$', num):
-            await ctx.author.send('Please include a valid question number. EX: $answer 1 /"Oct 12/" anonymous')
+        if not ans or ans.isspace():
+            await ctx.author.send("Please enter a valid answer.")
             await ctx.message.delete()
             return
 
-        #if not isinstance(ans, str):
-            #await ctx.author.send('Please include a valid answer. EX: $answer 1 /"Oct 12/" anonymous')
-           # await ctx.message.delete()
-           # return
+#        if len(ans) == 0:
+#            await ctx.author.send('Answer too short.')
+#            await ctx.message.delete()
+#            return
 
         # get author
         if anonymous == '':
             author = ctx.message.author.id
         elif anonymous == 'anonymous':
             author = None
+        elif anonymous == 'anon':
+            author = None
         else:
-            await ctx.author.send('Unknown input for *anonymous* option. Please type **anonymous** or leave blank.')
+            await ctx.author.send('Unknown input for *anonymous* option. Please type **anonymous**, **anon**, or leave blank.')
+            await ctx.message.delete()
+            return
+
+        # to stop SQL from freezing. Only allows valid numbers.
+        if not re.match(r'^([1-9]\d*|0)$', num):
+            await ctx.author.send('Please include a valid question number. EX: $answer 1 /"Oct 12/" anonymous')
             await ctx.message.delete()
             return
 

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -368,7 +368,7 @@ async def test_qanda(bot):
     # GHOST AND ZOMBIE TESTING
 
     # ask and dequeue
-    await dpytest.message("$ask \"Am I a zombie?\" anonymous", channel=channel)
+    await dpytest.message("$ask \"Am I a zombie?\" anon", channel=channel)
     assert dpytest.verify().message().contains().content(
         'Q3: Am I a zombie? by anonymous')
 
@@ -414,7 +414,7 @@ async def test_qanda(bot):
     assert dpytest.verify().message().contains().content(
         'Q4: Am I a ghost? by anonymous')
     # answer Q4
-    await dpytest.message("$answer 4 \"Yes\" anonymous", channel=channel)
+    await dpytest.message("$answer 4 \"Yes\" anon", channel=channel)
 
     # ask and dequeue
     await dpytest.message("$ask \"Zombie\" anonymous", channel=channel)
@@ -602,7 +602,7 @@ async def test_qanda_errors(bot):
     # Tests unknown anonymous input (question)
     await dpytest.message("$ask \"Who am I?\" wronganon", channel=channel)
     assert dpytest.verify().message().contains().content(
-        'Unknown input for *anonymous* option. Please type **anonymous** or leave blank.')
+        'Unknown input for *anonymous* option. Please type **anonymous**, **anon**, or leave blank.')
 
     # Tests incorrect use of ask command: missing args
     with pytest.raises(commands.MissingRequiredArgument):
@@ -621,7 +621,7 @@ async def test_qanda_errors(bot):
     # Tests unknown anonymous input (answer)
     await dpytest.message("$answer 1 \"A Thing\" wronganon", channel=channel)
     assert dpytest.verify().message().contains().content(
-        'Unknown input for *anonymous* option. Please type **anonymous** or leave blank.')
+        'Unknown input for *anonymous* option. Please type **anonymous**, **anon**, or leave blank.')
 
     # Tests answering a nonexistent question (answer)
     await dpytest.message("$answer 100 \"nope\"", channel=channel)
@@ -763,7 +763,6 @@ async def test_qanda_errors(bot):
     assert dpytest.verify().message().contains().content(
         'Please use this command inside the #q-and-a channel.')
 
-
     # allChannelGhosts without any ghosts
     await dpytest.message("$allChannelGhosts", channel=channel)
     assert dpytest.verify().message().contains().content(
@@ -810,6 +809,32 @@ async def test_qanda_errors(bot):
     await dpytest.message("$reviveGhost 1", channel=channel)
     assert dpytest.verify().message().contains().content(
         "No such question with the number: 1")
+
+    # Test ask: empty question
+    await dpytest.message("$ask \"\"", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        "Please enter a valid question.")
+
+    # Test ask: whitepaces only
+    await dpytest.message("$ask \"   \"", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        "Please enter a valid question.")
+
+    # Test ask: one char question
+    await dpytest.message("$ask \"A\"", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        "Question too short.")
+
+    # Test answer: empty answer
+    await dpytest.message("$answer 1 \"\"", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        "Please enter a valid answer.")
+
+    # Test answer: whitespaces only
+    await dpytest.message("$answer 1 \"    \"", channel=channel)
+    assert dpytest.verify().message().contains().content(
+        "Please enter a valid answer.")
+
 
 # --------------------
 # Tests cogs/reviewQs


### PR DESCRIPTION
* Users can now use "anon" when answering/asking questions
* Bugfix: prevent empty or whitespace questions/answers +5 test cases
